### PR TITLE
Revert previous pull request (shades remote UI and color change)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,6 @@
       "version": "0.1.0",
       "dependencies": {
         "@aws-amplify/ui-react": "^4.6.0",
-        "@emotion/react": "^11.13.0",
-        "@emotion/styled": "^11.13.0",
-        "@mui/icons-material": "^5.16.7",
-        "@mui/material": "^5.16.7",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -7660,20 +7656,15 @@
       "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA=="
     },
     "node_modules/@babel/runtime": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.0.tgz",
-      "integrity": "sha512-7dRy4DwXwtzBrPbZflqxnvfxLF8kdZXPkhymtDeFoFqE6ldzjQFgYTtYIFARcLEYDrqfBfYcZt1WqFxRoyC9Rw==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
+      "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
       "dependencies": {
-        "regenerator-runtime": "^0.14.0"
+        "regenerator-runtime": "^0.13.11"
       },
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@babel/runtime/node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/@babel/template": {
       "version": "7.24.7",
@@ -7995,158 +7986,6 @@
       "peerDependencies": {
         "postcss-selector-parser": "^6.0.10"
       }
-    },
-    "node_modules/@emotion/babel-plugin": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.12.0.tgz",
-      "integrity": "sha512-y2WQb+oP8Jqvvclh8Q55gLUyb7UFvgv7eJfsj7td5TToBrIUtPay2kMrZi4xjq9qw2vD0ZR5fSho0yqoFgX7Rw==",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.16.7",
-        "@babel/runtime": "^7.18.3",
-        "@emotion/hash": "^0.9.2",
-        "@emotion/memoize": "^0.9.0",
-        "@emotion/serialize": "^1.2.0",
-        "babel-plugin-macros": "^3.1.0",
-        "convert-source-map": "^1.5.0",
-        "escape-string-regexp": "^4.0.0",
-        "find-root": "^1.1.0",
-        "source-map": "^0.5.7",
-        "stylis": "4.2.0"
-      }
-    },
-    "node_modules/@emotion/babel-plugin/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@emotion/babel-plugin/node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@emotion/cache": {
-      "version": "11.13.1",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.13.1.tgz",
-      "integrity": "sha512-iqouYkuEblRcXmylXIwwOodiEK5Ifl7JcX7o6V4jI3iW4mLXX3dmt5xwBtIkJiQEXFAI+pC8X0i67yiPkH9Ucw==",
-      "dependencies": {
-        "@emotion/memoize": "^0.9.0",
-        "@emotion/sheet": "^1.4.0",
-        "@emotion/utils": "^1.4.0",
-        "@emotion/weak-memoize": "^0.4.0",
-        "stylis": "4.2.0"
-      }
-    },
-    "node_modules/@emotion/hash": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
-      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g=="
-    },
-    "node_modules/@emotion/is-prop-valid": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.3.0.tgz",
-      "integrity": "sha512-SHetuSLvJDzuNbOdtPVbq6yMMMlLoW5Q94uDqJZqy50gcmAjxFkVqmzqSGEFq9gT2iMuIeKV1PXVWmvUhuZLlQ==",
-      "dependencies": {
-        "@emotion/memoize": "^0.9.0"
-      }
-    },
-    "node_modules/@emotion/memoize": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
-      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ=="
-    },
-    "node_modules/@emotion/react": {
-      "version": "11.13.0",
-      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.13.0.tgz",
-      "integrity": "sha512-WkL+bw1REC2VNV1goQyfxjx1GYJkcc23CRQkXX+vZNLINyfI7o+uUn/rTGPt/xJ3bJHd5GcljgnxHf4wRw5VWQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "@emotion/babel-plugin": "^11.12.0",
-        "@emotion/cache": "^11.13.0",
-        "@emotion/serialize": "^1.3.0",
-        "@emotion/use-insertion-effect-with-fallbacks": "^1.1.0",
-        "@emotion/utils": "^1.4.0",
-        "@emotion/weak-memoize": "^0.4.0",
-        "hoist-non-react-statics": "^3.3.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@emotion/serialize": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.0.tgz",
-      "integrity": "sha512-jACuBa9SlYajnpIVXB+XOXnfJHyckDfe6fOpORIM6yhBDlqGuExvDdZYHDQGoDf3bZXGv7tNr+LpLjJqiEQ6EA==",
-      "dependencies": {
-        "@emotion/hash": "^0.9.2",
-        "@emotion/memoize": "^0.9.0",
-        "@emotion/unitless": "^0.9.0",
-        "@emotion/utils": "^1.4.0",
-        "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@emotion/sheet": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
-      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg=="
-    },
-    "node_modules/@emotion/styled": {
-      "version": "11.13.0",
-      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.13.0.tgz",
-      "integrity": "sha512-tkzkY7nQhW/zC4hztlwucpT8QEZ6eUzpXDRhww/Eej4tFfO0FxQYWRyg/c5CCXa4d/f174kqeXYjuQRnhzf6dA==",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "@emotion/babel-plugin": "^11.12.0",
-        "@emotion/is-prop-valid": "^1.3.0",
-        "@emotion/serialize": "^1.3.0",
-        "@emotion/use-insertion-effect-with-fallbacks": "^1.1.0",
-        "@emotion/utils": "^1.4.0"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.0.0-rc.0",
-        "react": ">=16.8.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@emotion/unitless": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.9.0.tgz",
-      "integrity": "sha512-TP6GgNZtmtFaFcsOgExdnfxLLpRDla4Q66tnenA9CktvVSdNKDvMVuUah4QvWPIpNjrWsGg3qeGo9a43QooGZQ=="
-    },
-    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.1.0.tgz",
-      "integrity": "sha512-+wBOcIV5snwGgI2ya3u99D7/FJquOIniQT1IKyDsBmEgwvpxMNeS65Oib7OnE2d2aY+3BU4OiH+0Wchf8yk3Hw==",
-      "peerDependencies": {
-        "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@emotion/utils": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.0.tgz",
-      "integrity": "sha512-spEnrA1b6hDR/C68lC2M7m6ALPUHZC0lIY7jAS/B/9DuuO1ZP04eov8SMv/6fwRd8pzmsn2AuJEznRREWlQrlQ=="
-    },
-    "node_modules/@emotion/weak-memoize": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
-      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg=="
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -9342,232 +9181,6 @@
         "maplibre-gl": ">=1.14.0"
       }
     },
-    "node_modules/@mui/core-downloads-tracker": {
-      "version": "5.16.7",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.16.7.tgz",
-      "integrity": "sha512-RtsCt4Geed2/v74sbihWzzRs+HsIQCfclHeORh5Ynu2fS4icIKozcSubwuG7vtzq2uW3fOR1zITSP84TNt2GoQ==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      }
-    },
-    "node_modules/@mui/icons-material": {
-      "version": "5.16.7",
-      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.16.7.tgz",
-      "integrity": "sha512-UrGwDJCXEszbDI7yV047BYU5A28eGJ79keTCP4cc74WyncuVrnurlmIRxaHL8YK+LI1Kzq+/JM52IAkNnv4u+Q==",
-      "dependencies": {
-        "@babel/runtime": "^7.23.9"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@mui/material": "^5.0.0",
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/material": {
-      "version": "5.16.7",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.16.7.tgz",
-      "integrity": "sha512-cwwVQxBhK60OIOqZOVLFt55t01zmarKJiJUWbk0+8s/Ix5IaUzAShqlJchxsIQ4mSrWqgcKCCXKtIlG5H+/Jmg==",
-      "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@mui/core-downloads-tracker": "^5.16.7",
-        "@mui/system": "^5.16.7",
-        "@mui/types": "^7.2.15",
-        "@mui/utils": "^5.16.6",
-        "@popperjs/core": "^2.11.8",
-        "@types/react-transition-group": "^4.4.10",
-        "clsx": "^2.1.0",
-        "csstype": "^3.1.3",
-        "prop-types": "^15.8.1",
-        "react-is": "^18.3.1",
-        "react-transition-group": "^4.4.5"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.5.0",
-        "@emotion/styled": "^11.3.0",
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        },
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/material/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
-    },
-    "node_modules/@mui/private-theming": {
-      "version": "5.16.6",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.16.6.tgz",
-      "integrity": "sha512-rAk+Rh8Clg7Cd7shZhyt2HGTTE5wYKNSJ5sspf28Fqm/PZ69Er9o6KX25g03/FG2dfpg5GCwZh/xOojiTfm3hw==",
-      "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@mui/utils": "^5.16.6",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/styled-engine": {
-      "version": "5.16.6",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.16.6.tgz",
-      "integrity": "sha512-zaThmS67ZmtHSWToTiHslbI8jwrmITcN93LQaR2lKArbvS7Z3iLkwRoiikNWutx9MBs8Q6okKvbZq1RQYB3v7g==",
-      "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@emotion/cache": "^11.11.0",
-        "csstype": "^3.1.3",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.4.1",
-        "@emotion/styled": "^11.3.0",
-        "react": "^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/system": {
-      "version": "5.16.7",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.16.7.tgz",
-      "integrity": "sha512-Jncvs/r/d/itkxh7O7opOunTqbbSSzMTHzZkNLM+FjAOg+cYAZHrPDlYe1ZGKUYORwwb2XexlWnpZp0kZ4AHuA==",
-      "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@mui/private-theming": "^5.16.6",
-        "@mui/styled-engine": "^5.16.6",
-        "@mui/types": "^7.2.15",
-        "@mui/utils": "^5.16.6",
-        "clsx": "^2.1.0",
-        "csstype": "^3.1.3",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.5.0",
-        "@emotion/styled": "^11.3.0",
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        },
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/types": {
-      "version": "7.2.15",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.15.tgz",
-      "integrity": "sha512-nbo7yPhtKJkdf9kcVOF8JZHPZTmqXjJ/tI0bdWgHg5tp9AnIN4Y7f7wm9T+0SyGYJk76+GYZ8Q5XaTYAsUHN0Q==",
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/utils": {
-      "version": "5.16.6",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.16.6.tgz",
-      "integrity": "sha512-tWiQqlhxAt3KENNiSRL+DIn9H5xNVK6Jjf70x3PnfQPz1MPBdh7yyIcAyVBT9xiw7hP3SomRhPR7hzBMBCjqEA==",
-      "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@mui/types": "^7.2.15",
-        "@types/prop-types": "^15.7.12",
-        "clsx": "^2.1.1",
-        "prop-types": "^15.8.1",
-        "react-is": "^18.3.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/utils/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
-    },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
@@ -9675,15 +9288,6 @@
         "webpack-plugin-serve": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@popperjs/core": {
-      "version": "2.11.8",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -12936,9 +12540,9 @@
       "integrity": "sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg=="
     },
     "node_modules/@types/prop-types": {
-      "version": "15.7.12",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
-      "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q=="
+      "version": "15.7.5",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
     "node_modules/@types/q": {
       "version": "1.5.5",
@@ -12976,14 +12580,6 @@
       "version": "0.28.6",
       "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.6.tgz",
       "integrity": "sha512-NlilRDg7yjtFX568NA046OiHWbz5EKM1q5FSXi2GP7WKyU+Vem4NJQcG+ZaMiWotyPiYqkIb6NKJkFuplbchAA==",
-      "dependencies": {
-        "@types/react": "*"
-      }
-    },
-    "node_modules/@types/react-transition-group": {
-      "version": "4.4.10",
-      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.10.tgz",
-      "integrity": "sha512-hT/+s0VQs2ojCX823m60m5f0sL5idt9SO6Tj6Dg+rdphGPIeJbJ6CxvBYkgkGKrYeDjvIpKTR38UzmtHJOGW3Q==",
       "dependencies": {
         "@types/react": "*"
       }
@@ -14983,14 +14579,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/clsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -15722,9 +15310,9 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
+      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -16025,15 +15613,6 @@
       "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
       "dependencies": {
         "utila": "~0.4"
-      }
-    },
-    "node_modules/dom-helpers": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
-      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
-      "dependencies": {
-        "@babel/runtime": "^7.8.7",
-        "csstype": "^3.0.2"
       }
     },
     "node_modules/dom-serializer": {
@@ -17480,11 +17059,6 @@
         "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
       }
     },
-    "node_modules/find-root": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
-    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -18242,19 +17816,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "dependencies": {
-        "react-is": "^16.7.0"
-      }
-    },
-    "node_modules/hoist-non-react-statics/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/hoopy": {
       "version": "0.1.4",
@@ -27371,21 +26932,6 @@
         }
       }
     },
-    "node_modules/react-transition-group": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
-      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
-      "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "dom-helpers": "^5.0.1",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0",
-        "react-dom": ">=16.6.0"
-      }
-    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -28850,11 +28396,6 @@
       "peerDependencies": {
         "postcss": "^8.2.15"
       }
-    },
-    "node_modules/stylis": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
-      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
     },
     "node_modules/subtag": {
       "version": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -4,10 +4,6 @@
   "private": true,
   "dependencies": {
     "@aws-amplify/ui-react": "^4.6.0",
-    "@emotion/react": "^11.13.0",
-    "@emotion/styled": "^11.13.0",
-    "@mui/icons-material": "^5.16.7",
-    "@mui/material": "^5.16.7",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/src/ecommerce/ecommerce.css
+++ b/src/ecommerce/ecommerce.css
@@ -1,4 +1,4 @@
-main#ecommerce {
+#ecommerce {
    padding: 20px;
 
    display: flex;

--- a/src/home/home.css
+++ b/src/home/home.css
@@ -28,6 +28,8 @@ main#home {
 }
 
 .home-slider-button {
+   color: white;
+   fill: white;
    opacity: 0.8;
    font-size: .5em;
    cursor: pointer;

--- a/src/home/timeline.css
+++ b/src/home/timeline.css
@@ -55,7 +55,6 @@
 }
 .timeline-event-content > h3 {
    margin-bottom: 0.5em;
-   text-align: inherit;
 }
 .timeline-event-content > ul > li {
    margin-bottom: 0.3em;
@@ -87,6 +86,7 @@
       margin-left: 7%;
    }
 }
+
 
 @media screen and ( max-width: 768px ) {
    /* Get rid of left-side padding on parent container */

--- a/src/home/timeline.jsx
+++ b/src/home/timeline.jsx
@@ -3,14 +3,21 @@ import './timeline.css';
 
 const timelineEventList = [
   {
-    title: "Software Engineer",
-    employer: "Honeywell Aerospace Technologies",
-    startDate: "August 2023",
-    endDate: "Present",
+    title: "Shift Manager",
+    employer: "Dairy Queen",
+    startDate: "February 2019",
+    endDate: "August 2021",
     description: [
-      "Write and verify requirements, software, and tests for aircraft Inertial Reference Units (IRUs)",
-      "Run and analyze flight simulations to verify software performance",
+      "Managed and trained employees to ensure quality customer service.",
+      "Supported a safe work environment by properly cleaning and maintaining equipment."
     ]
+  },
+  {
+    title: "Security Monitor",
+    employer: "University of Minnesota",
+    startDate: "October 2021",
+    endDate: "May 2022",
+    description: "Kept constant, concise, and meticulous communication via logging and radio discussion. Held continuous surveillance and campus building patrols to ensure security and safety for both students and faculty, and provided assistance to students with safe travel through UMN’s 24/7 safe-walk program."
   },
   {
     title: "Firmware Engineering Intern",
@@ -22,37 +29,20 @@ const timelineEventList = [
       "Effectively utilized engineering strategies while addressing problems to improve adaptability and robustness of code.",
       "Frequent discussion with stakeholders to find the ideal implementation of systems."
     ]
-  },
-  {
-    title: "Security Monitor",
-    employer: "University of Minnesota",
-    startDate: "October 2021",
-    endDate: "May 2022",
-    description: "Kept constant, concise, and meticulous communication via logging and radio discussion. Held continuous surveillance and campus building patrols to ensure security and safety for both students and faculty, and provided assistance to students with safe travel through UMN’s 24/7 safe-walk program."
-  },
-  {
-    title: "Shift Manager",
-    employer: "Dairy Queen",
-    startDate: "February 2019",
-    endDate: "August 2021",
-    description: [
-      "Managed and trained employees to ensure quality customer service.",
-      "Supported a safe work environment by properly cleaning and maintaining equipment."
-    ]
   }
 ];
 
 function TimelineEvent( props )
 {
   const isEventIndexEven = ( props.eventIndex % 2 === 0 );
-  
+
   return (
     <div className={ isEventIndexEven ? "timeline-event right" : "timeline-event left" }>
       { isEventIndexEven ? <h3 className="timeline-date-range">{ props.startDate } - { props.endDate }</h3> : <></> }
       <i className="timeline-circle" />
       <div className="timeline-event-content">
-        <h2>{ props.employer }</h2>
-        <h3>{ props.title }</h3>
+        <h2>{ props.title }</h2>
+        <h3>{ props.employer }</h3>
         <ul>
           { ( props.description instanceof Array )
               ? props.description.map( ( bulletPoint ) => (

--- a/src/index.css
+++ b/src/index.css
@@ -16,11 +16,17 @@ h1, h2, h3, h4, h5, h6 {
 p {
   margin: 0;
 }
-
-/* Hide scrollbar for IE, Edge and Firefox */
+  
 body {
   margin: 0;
   padding: 0;
+
+  font-family: 'Lato', 'Cera Round Pro', sans-serif;
+  font-weight: 400;
+  color: white;
+  background-color: rgb( 20, 20, 20 );
+
+  /* Hide scrollbar for IE, Edge and Firefox */
   -ms-overflow-style: none;  /* IE and Edge */
   scrollbar-width: none;  /* Firefox */
 }

--- a/src/shades_remote/shades_remote.css
+++ b/src/shades_remote/shades_remote.css
@@ -1,7 +1,11 @@
 main#shades-remote {
+   position: relative;
    display: flex;
    flex-direction: column;
-   padding: 20px;
-   justify-content: center;
-   align-items: center;
+}
+
+main h1 {
+   font-size: 1.5em;
+   margin: 0;
+   padding: 0;
 }

--- a/src/shades_remote/shades_remote.css
+++ b/src/shades_remote/shades_remote.css
@@ -1,6 +1,7 @@
 main#shades-remote {
-   padding: 20px;
    display: flex;
+   flex-direction: column;
+   padding: 20px;
    justify-content: center;
    align-items: center;
 }

--- a/src/shades_remote/shades_remote.jsx
+++ b/src/shades_remote/shades_remote.jsx
@@ -1,95 +1,70 @@
 import * as React from 'react';
-import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
-import ToggleButton from '@mui/material/ToggleButton';
 import Stack from '@mui/material/Stack';
-import Divider from '@mui/material/Divider';
+import Button from '@mui/material/Button';
+import ToggleButton from '@mui/material/ToggleButton';
+import CheckIcon from '@mui/icons-material/Check';
 import "./shades_remote.css";
+import { whistle } from 'fontawesome';
 
 const ip_address = '10.0.0.219';
 
-function ShadesRemote( )
+function sendPostRequest( parameter )
 {
-    const [shadesState, setShadesState] = React.useState('');
-    const [mode, setMode] = React.useState('');
-    const [inhibitButtons, setInhibitButtons] = React.useState(false);
-    
-    const handleStateChange = ( event, newState ) =>
-    {
-        setInhibitButtons(true);
-        fetch('http://' + ip_address + '/' + newState, {method: 'POST'})
-        .then(response => {console.log(response)})
-        .then(setShadesState(newState))
-        .catch(err => {console.error('Error sending ' + newState + ' to ' + ip_address + '\n\n' + err)})
-        .finally(() => {setInhibitButtons(false)});
+    const options = {
+        method: 'POST'
     }
 
-    const handleModeChange = ( event, newMode ) =>
-    {
-        setInhibitButtons(true);
-        fetch('http://' + ip_address + '/mode/' + newMode, {method: 'POST'})
+    fetch('http://' + ip_address + '/' + parameter, options)
         .then(response => {console.log(response)})
-        .then(setMode(newMode))
-        .catch(err => {console.error('Error transitioning to ' + newMode + ' mode at ' + ip_address + '\n\n' + err)})
-        .finally(() => {setInhibitButtons(false)});
-    }
-    
-    React.useEffect( ( ) => {
-        fetch('http://' + ip_address)
-            .then(response => {response.json()})
-            .then(data => {
-                setShadesState(data.state);
-                setMode(data.mode);
-            })
-            .catch(err => {
-                console.error('Error reading shades state and mode from ' + ip_address + '\n\n' + err);
-            });
-    }, [ ] );
+        .catch(err => {
+            console.error('Error opening shades at ' + ip_address + '\n\n' + err);
+        });
+}
+
+function ShadesRemote( )
+{
+    const [shadesState, setShadesState] = React.useState('Loading...');
+    const [selected, setSelected] = React.useState(false);
+
+    // useEffect( ( ) => {
+    //     fetch('http://' + ip_address)
+    //         .then(response => {console.log(response); return response.json();})
+    //         .then(data => {
+    //             setShadesState(data.state);
+    //         })
+    //         .catch(err => {
+    //             console.error('Error reading shades state from ' + ip_address + '\n\n' + err);
+    //         });
+    // }, [ ] );
 
     return (
         <main id="shades-remote">
-            <Stack spacing={2} divider={<Divider orientation="horizontal" flexItem />}>
-                {/* title */}
-                <h1 style={{textAlign: "center"}}>Shades Remote</h1>
-
-                {/* Open/close control */}
-                <Stack direction="row" spacing={2} alignItems="center">
-                    <h2 style={{lineHeight: 1}}>Current state:</h2>
-                    <ToggleButtonGroup
-                        value={shadesState}
-                        exclusive
-                        onChange={handleStateChange}
-                        aria-label="shades state"
-                    >
-                        <ToggleButton value="open" aria-label="open shades" disabled={inhibitButtons}>
-                            OPEN
-                        </ToggleButton>
-                        <ToggleButton value="close" aria-label="close shades" disabled={inhibitButtons}>
-                            CLOSE
-                        </ToggleButton>
-                    </ToggleButtonGroup>
-                </Stack>
-
-                {/* Mode control */}
-                <Stack direction="row" spacing={2} alignItems="center">
-                    <h2 style={{lineHeight: 1}}>Mode:</h2>
-                    <ToggleButtonGroup
-                        value={mode}
-                        exclusive
-                        onChange={handleModeChange}
-                        aria-label="shades mode"
-                    >
-                        <ToggleButton value="normal" aria-label="normal mode" disabled={inhibitButtons}>
-                            NORMAL
-                        </ToggleButton>
-                        <ToggleButton value="important" aria-label="important mode" disabled={inhibitButtons}>
-                            IMPORTANT
-                        </ToggleButton>
-                    </ToggleButtonGroup>
-                </Stack>
-
-                {/* Alarm control */}
-                <h2 style={{lineHeight: 1}}>Next Alarm: 7:00 AM</h2>
+            <h1>Shades Remote</h1>
+            <Stack spacing={2} direction="column">
+                <Button variant="contained" onClick={(e) => {sendPostRequest('open')}}>Open</Button>
+                <Button variant="contained" onClick={(e) => {sendPostRequest('close')}}>Close</Button>
+                <h2>Important Mode:</h2>
+                <ToggleButton
+                    value="check"
+                    selected={selected}
+                    onChange={(e) => {setSelected(!selected)}}
+                    sx={{
+                        bgcolor: "black",
+                        color: "white",
+                        "&.Mui-selected": {
+                            bgcolor: "white",
+                            color: "black",
+                        },
+                        "&.Mui-selected:hover": {
+                            bgcolor: "black",
+                            color: "white",
+                        }
+                    }}
+                >
+                    <CheckIcon />
+                </ToggleButton>
             </Stack>
+            <h2>{shadesState}</h2>
         </main>
     );
 }

--- a/src/shades_remote/shades_remote.jsx
+++ b/src/shades_remote/shades_remote.jsx
@@ -1,33 +1,36 @@
-import {useState} from "react";
 import "./shades_remote.css";
 
 const ip_address = '10.0.0.219';
 const port = '1024';
 
+const connectToWebSocket = () => {
+    const socket = new WebSocket('ws://' + ip_address + ':' + port);
+    socket.addEventListener("open", (event) =>
+    {
+        console.log('Connected to WebSocket');
+    });
+    socket.addEventListener("message", (event) =>
+    {
+        console.log('Message from server: ', event.data);
+    });
+    socket.addEventListener('close', () => {
+        console.log('Disconnected from WebSocket');
+    });
+    socket.addEventListener('error', (err) => {
+        console.log(err);
+    });
+}
+
 function ShadesRemote( )
 {
-    const [shadesState, setShadesState] = useState(0);
-
-    const getShadesState = () => {
-        fetch('http://' + ip_address + ':' + port)
-            .then(response => {console.log(response); return response.json();})
-            .then(data => {
-                setShadesState(data.state);
-            })
-            .catch(err => {
-                console.error('Error reading shades state from ' + ip_address + ':' + port + '\n\n' + err);
-            });
-    }
-
     return (
         <main id="shades-remote">
             <h1>Shades Remote</h1>
-            <button onClick={getShadesState}>Connect</button>
+            <button onClick={connectToWebSocket}>Connect</button>
             <button>Open</button>
             <button>Close</button>
             <button>Enable important mode</button>
             <button>Disable important mode</button>
-            <h2>{shadesState}</h2>
         </main>
     );
 }

--- a/src/shades_remote/shades_remote.jsx
+++ b/src/shades_remote/shades_remote.jsx
@@ -1,47 +1,35 @@
-import {useState, useEffect} from "react";
+import {useState} from "react";
 import "./shades_remote.css";
 
 const ip_address = '10.0.0.219';
-
-function sendPostRequest( parameter )
-{
-    const options = {
-        method: 'POST'
-    }
-
-    fetch('http://' + ip_address + '/' + parameter, options)
-        .then(response => {console.log(response)})
-        .catch(err => {
-            console.error('Error opening shades at ' + ip_address + '\n\n' + err);
-        });
-}
+const port = '1024';
 
 function ShadesRemote( )
 {
-    const [shadesState, setShadesState] = useState('Loading...');
+    const [shadesState, setShadesState] = useState(0);
 
-    useEffect( ( ) => {
-        fetch('http://' + ip_address)
+    const getShadesState = () => {
+        fetch('http://' + ip_address + ':' + port)
             .then(response => {console.log(response); return response.json();})
             .then(data => {
                 setShadesState(data.state);
             })
             .catch(err => {
-                console.error('Error reading shades state from ' + ip_address + '\n\n' + err);
+                console.error('Error reading shades state from ' + ip_address + ':' + port + '\n\n' + err);
             });
-    }, [ ] );
+    }
 
     return (
         <main id="shades-remote">
             <h1>Shades Remote</h1>
-            <button onClick={(e) => {sendPostRequest('open')}}>Open</button>
-            <button onClick={(e) => {sendPostRequest('close')}}>Close</button>
-            <button onClick={(e) => {sendPostRequest('important_mode_on')}}>Enable important mode</button>
-            <button onClick={(e) => {sendPostRequest('important_mode_ff')}}>Disable important mode</button>
+            <button onClick={getShadesState}>Connect</button>
+            <button>Open</button>
+            <button>Close</button>
+            <button>Enable important mode</button>
+            <button>Disable important mode</button>
             <h2>{shadesState}</h2>
         </main>
     );
 }
-
 
 export default ShadesRemote;

--- a/src/shades_remote/shades_remote.jsx
+++ b/src/shades_remote/shades_remote.jsx
@@ -1,10 +1,5 @@
-import * as React from 'react';
-import Stack from '@mui/material/Stack';
-import Button from '@mui/material/Button';
-import ToggleButton from '@mui/material/ToggleButton';
-import CheckIcon from '@mui/icons-material/Check';
+import {useState, useEffect} from "react";
 import "./shades_remote.css";
-import { whistle } from 'fontawesome';
 
 const ip_address = '10.0.0.219';
 
@@ -23,47 +18,26 @@ function sendPostRequest( parameter )
 
 function ShadesRemote( )
 {
-    const [shadesState, setShadesState] = React.useState('Loading...');
-    const [selected, setSelected] = React.useState(false);
+    const [shadesState, setShadesState] = useState('Loading...');
 
-    // useEffect( ( ) => {
-    //     fetch('http://' + ip_address)
-    //         .then(response => {console.log(response); return response.json();})
-    //         .then(data => {
-    //             setShadesState(data.state);
-    //         })
-    //         .catch(err => {
-    //             console.error('Error reading shades state from ' + ip_address + '\n\n' + err);
-    //         });
-    // }, [ ] );
+    useEffect( ( ) => {
+        fetch('http://' + ip_address)
+            .then(response => {console.log(response); return response.json();})
+            .then(data => {
+                setShadesState(data.state);
+            })
+            .catch(err => {
+                console.error('Error reading shades state from ' + ip_address + '\n\n' + err);
+            });
+    }, [ ] );
 
     return (
         <main id="shades-remote">
             <h1>Shades Remote</h1>
-            <Stack spacing={2} direction="column">
-                <Button variant="contained" onClick={(e) => {sendPostRequest('open')}}>Open</Button>
-                <Button variant="contained" onClick={(e) => {sendPostRequest('close')}}>Close</Button>
-                <h2>Important Mode:</h2>
-                <ToggleButton
-                    value="check"
-                    selected={selected}
-                    onChange={(e) => {setSelected(!selected)}}
-                    sx={{
-                        bgcolor: "black",
-                        color: "white",
-                        "&.Mui-selected": {
-                            bgcolor: "white",
-                            color: "black",
-                        },
-                        "&.Mui-selected:hover": {
-                            bgcolor: "black",
-                            color: "white",
-                        }
-                    }}
-                >
-                    <CheckIcon />
-                </ToggleButton>
-            </Stack>
+            <button onClick={(e) => {sendPostRequest('open')}}>Open</button>
+            <button onClick={(e) => {sendPostRequest('close')}}>Close</button>
+            <button onClick={(e) => {sendPostRequest('important_mode_on')}}>Enable important mode</button>
+            <button onClick={(e) => {sendPostRequest('important_mode_ff')}}>Disable important mode</button>
             <h2>{shadesState}</h2>
         </main>
     );


### PR DESCRIPTION
The shades remote does not work when served over HTTPS. Modern browsers don't allow HTTP requests that aren't encrypted when the website itself is served over HTTPS.

The shades remote functionality is replaced by an app installed on my phone that sends HTTP requests.

Reverting this change also removes the dependency on MUI